### PR TITLE
Got rid of app.router deprecated error

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -12,9 +12,8 @@ wrap = (fn, method, path) -> (spath, a...) ->
     fn.call this, path, spath, a...
 
 subroute = (app, path, fn) ->
-  # ensure the router is used. attempting to enable it later
-  # via the wrapped use() will not work.
-  app.use app.router unless app._usedRouter
+  # XXX app.router is deprecated in current version of express
+  #app.use app.router unless app._usedRouter
 
   sapp = Object.create app, _methods: value: {}
   sapp[method] = wrap app[method], method, path for method in path_methods


### PR DESCRIPTION
In current version, app.router is automatically used, and checking for app.router causes an error.
I commented out the line where you check for app.router, and the error is now gone.
Everything else seems working fine with current version of express (4.10.6).
