### PR TITLE
Adding Allow header when response is 405

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -19,7 +19,7 @@ subroute = (app, path, fn) ->
   unless sapp._methods.options?
     sapp.options (req, res) -> res.header('Allow', allowed).end()
     allowed = (Object.keys sapp._methods).join(',').toUpperCase()
-  sapp.all (req, res) -> res.send 405
+  sapp.all (req, res) -> res.header('Allow', allowed).sendStatus(405)
  
 subroute.install = (app = (require 'express').application) -> app.subroute = curryThis subroute
  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-subroute",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Nadav Ivgi <gh@shesek.info>",
   "license": "WTFPL",
   "repository": "git://github.com/shesek/express-subroute",


### PR DESCRIPTION
Added Allow header with 405 response as mentioned in http spec. Also updating to use res.sendStatus(405) over deprecated method res.send(405).
